### PR TITLE
Fix typo in exercise

### DIFF
--- a/source/firstlook05.ptx
+++ b/source/firstlook05.ptx
@@ -576,7 +576,7 @@
 
         <exercise>
             <statement>
-                <p>A manager in a communications company contributes $2400 per year into her retirement fund by making many small deposits throughout the year.  The fund grows at a rate of 3.5% per year compounded continuously.  After 35 years, she retires and begins and begins withdrawing from the retirement fund at a rate of $3500 per month.  If she does not make any deposits after she retires, how long will her retirement fund last?  [<em>Hint</em>: Divide the problem into two smaller problems<mdash />one that deals with the situation before retirement and one that deals with the problem after retirement.]</p>
+                <p>A manager in a communications company contributes $2400 per year into her retirement fund by making many small deposits throughout the year.  The fund grows at a rate of 3.5% per year compounded continuously.  After 35 years, she retires and begins withdrawing from the retirement fund at a rate of $3500 per month.  If she does not make any deposits after she retires, how long will her retirement fund last?  [<em>Hint</em>: Divide the problem into two smaller problems<mdash />one that deals with the situation before retirement and one that deals with the problem after retirement.]</p>
             </statement>
 
         </exercise>


### PR DESCRIPTION
The words "and begins" were repeated twice.