### PR TITLE
Fix typo (r -> x) in Spruce Budworm project

### DIFF
--- a/source/firstlook08.ptx
+++ b/source/firstlook08.ptx
@@ -40,7 +40,7 @@
                         <me>x' = rx(1-x) - \frac{x^2}{0.01 + x^2}.</me>
                     Solve the equation
                         <me>rx(1-x) - \frac{x^2}{0.01 + x^2} = 0</me>
-                    and plot the result in the <m>xr</m>-plane for <m>0 \leq r \lt 1</m>.</p>
+                    and plot the result in the <m>xr</m>-plane for <m>0 \leq x \lt 1</m>.</p>
                 </statement>
             </task>
 


### PR DESCRIPTION
The project suggests plotting the bifurcation diagram for 0 ≤ r < 1.  This should be 0 ≤ x < 1.  A more reasonable value for r is 0 ≤ r ≤ 10.

(Also, rather than plotting r as a function of x and then reflecting, a more direct approach is to use Sage's implicit_plot.)