### PR TITLE
Fix typo in exercise

### DIFF
--- a/source/firstlook05.ptx
+++ b/source/firstlook05.ptx
@@ -971,7 +971,7 @@
 
         <exercise>
             <statement>
-                <p>A manager in a communications company contributes $2400 per year into her retirement fund by making many small deposits throughout the year.  The fund grows at a rate of 3.5% per year compounded continuously.  After 35 years, she retires and begins and begins withdrawing from the retirement fund at a rate of $3500 per month.  If she does not make any deposits after she retires, how long will her retirement fund last?</p>
+                <p>A manager in a communications company contributes $2400 per year into her retirement fund by making many small deposits throughout the year.  The fund grows at a rate of 3.5% per year compounded continuously.  After 35 years, she retires and begins withdrawing from the retirement fund at a rate of $3500 per month.  If she does not make any deposits after she retires, how long will her retirement fund last?</p>
             </statement>
             <hint>
                 <p>

--- a/source/firstlook08.ptx
+++ b/source/firstlook08.ptx
@@ -40,7 +40,7 @@
                         <md>x' = rx(1-x) - \frac{x^2}{0.01 + x^2}.</md>
                     Solve the equation
                         <md>rx(1-x) - \frac{x^2}{0.01 + x^2} = 0</md>
-                    and plot the result in the <m>xr</m>-plane for <m>0 \leq r \lt 1</m>.</p>
+                    and plot the result in the <m>xr</m>-plane for <m>0 \leq x \lt 1</m>.</p>
                 </statement>
             </task>
 

--- a/source/secondorder01.ptx
+++ b/source/secondorder01.ptx
@@ -353,7 +353,7 @@
 
         <p>If we add damping to the oscillator, the equation becomes
             <md number="yes" xml:id="secondorder01-equation-damped-oscillator">m \frac{d^2 x}{dt^2} + b \frac{dx}{dt} + k x = 0.</md>
-       where <m>b \gt 0</m>. The charactersitic equation of <xref ref="secondorder01-equation-damped-oscillator" /> is
+       where <m>b \gt 0</m>. The characteristic equation of <xref ref="secondorder01-equation-damped-oscillator" /> is
             <md>m\lambda^2 + b\lambda + k = 0</md>,
         which has roots
             <md number="yes" xml:id="secondorder01-equation-characteristic-eq-roots">\lambda = \frac{-b \pm \sqrt{b^2 - 4mk}}{2m}.</md>


### PR DESCRIPTION
This is the typo from #5, but without the merge conflict. I made sure the commit is still credited to the author of #5. That PR could be closed now.